### PR TITLE
Use default libs even if no external libs could be loaded

### DIFF
--- a/router/src/main/scala/scalafiddle/router/CompilerManager.scala
+++ b/router/src/main/scala/scalafiddle/router/CompilerManager.scala
@@ -57,7 +57,7 @@ class CompilerManager extends Actor with ActorLogging {
       version -> ((libUris.get(version), defaultLibs.get(version)) match {
         case (Some(uri), Some(versionLibs)) =>
           try {
-            log.debug(s"Loading libraries from $uri")
+            log.debug(s"Loading libraries from $uri for scala version $version")
             val data = if (uri.startsWith("file:")) {
               // load from file system
               scala.io.Source.fromFile(uri.drop(5), "UTF-8").mkString
@@ -75,8 +75,8 @@ class CompilerManager extends Actor with ActorLogging {
             (extLibs ++ versionLibs).map(ExtLib(_))
           } catch {
             case e: Throwable =>
-              log.error(e, s"Unable to load libraries")
-              Nil
+              log.error(e, s"Unable to load external libraries, only using default ones.")
+              versionLibs.map(ExtLib(_))
           }
         case _ =>
           Nil
@@ -104,7 +104,7 @@ class CompilerManager extends Actor with ActorLogging {
     log.debug(s"Selecting compiler for Scala $scalaVersion and libs $libs")
     // check that all libs are supported
     val versionLibs = currentLibs.getOrElse(scalaVersion, Vector.empty)
-    // log.debug(s"Libraries:\n$versionLibs")
+    log.debug(s"Libraries:\n$versionLibs")
     libs.foreach(lib => if (!versionLibs.contains(lib)) throw new IllegalArgumentException(s"Library $lib is not supported"))
     // select the best available compiler server based on:
     // 1) time of last activity


### PR DESCRIPTION
For my setup the router could not connect to the client and failed loading external libraries. This lead to the error message `Library org.scala-js %%% scalajs-dom % 0.9.4 is not supported`(line 108 in CompilerManager.scala) send to the browser, which seemed weird.

Apparently, the default libraries weren't added to the `currentLibs`. I fixed it by adding the default libraries even no external libraries could be loaded. 

**I hope my assumption is true, that default libraries are available in the classpath by design.**
