### PR TITLE
Configure Scala.js source mapping

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
+
+addSbtPlugin("com.thoughtworks.sbt-scala-js-map" % "sbt-scala-js-map" % "2.0.0")


### PR DESCRIPTION
This plugin will enable source mapping, which will help contributors of ScalaFiddle to debug.