### PR TITLE
Sjs 0.6.24

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "typesafe" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
 


### PR DESCRIPTION
When I was testing fiddles with Udash 0.7, I had encountered a linking error with `toScalaVarArgs` from Scala.js lib. The Scala.js upgrade fixed this issue. 