### PR TITLE
Update to scala:2.12.6 and scalajs:0.6.24

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,12 +6,12 @@ ThisBuild / scalafmtOnCompile := true
 
 val commonSettings = Seq(
   scalacOptions := scalacArgs,
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.6",
   version := versions.fiddle,
   libraryDependencies ++= Seq()
 )
 
-val crossVersions = crossScalaVersions := Seq("2.12.5", "2.11.12")
+val crossVersions = crossScalaVersions := Seq("2.12.6", "2.11.12")
 
 lazy val root = project
   .in(file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "typesafe" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
 


### PR DESCRIPTION
reactify is compiled with scalajs version 0.6.23 and it doesn't work with older one:

```
Referring to non-existent method scala.scalajs.runtime.package$.toScalaVarArgs(scala.scalajs.js.Array)scala.collection.Seq
```

- on [scalajs news site](https://www.scala-js.org/news/) is nothing about migration 0.6.22 -> 0.6.24 (assume that no other changes needed).
- Project was compiled and runned locally.