### PR TITLE
Upgrade the client project to Scala.js 1.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,11 @@ lazy val client = project
     // rename output always to -opt.js
     Compile / fastOptJS / artifactPath := ((Compile / fastOptJS / crossTarget).value /
       ((fastOptJS / moduleName).value + "-opt.js")),
-    relativeSourceMaps := true
+    scalaJSLinkerConfig := {
+      val artifactPathURI = (Compile / fastOptJS / artifactPath).value.toURI()
+      scalaJSLinkerConfig.value
+        .withRelativizeSourceMapBase(Some(artifactPathURI))
+    }
   )
 
 /* This project is configured so that it *compiles* as if it were a Scala.js

--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,7 @@ lazy val client = project
   .dependsOn(shared.js)
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-js"          %%% "scalajs-dom" % versions.dom,
-      "com.github.marklister" %%% "base64"      % versions.base64
+      "org.scala-js" %%% "scalajs-dom" % versions.dom
     ),
     //Compile / fullOptJS / scalaJSLinkerConfig ~= { _.withClosureCompilerIfAvailable(false) },
     // rename output always to -opt.js

--- a/client/src/main/scala/scalafiddle/client/Client.scala
+++ b/client/src/main/scala/scalafiddle/client/Client.scala
@@ -128,19 +128,18 @@ class Client(editURL: String) {
   }
 
   def encodeSource(source: String): String = {
-    import com.github.marklister.base64.Base64._
     import js.JSConverters._
 
-    implicit def scheme: B64Scheme = base64Url
-    val fullSource                 = source.getBytes(StandardCharsets.UTF_8)
-    val compressedBuffer           = new Gzip(fullSource.toJSArray).compress()
-    val compressedSource           = new Array[Byte](compressedBuffer.length)
-    var i                          = 0
-    while (i < compressedBuffer.length) {
-      compressedSource(i) = compressedBuffer.get(i).toByte
-      i += 1
+    val fullSource           = source.getBytes(StandardCharsets.UTF_8)
+    val compressedTypedArray = new Gzip(fullSource.toJSArray).compress()
+    val compressedBuffer     = js.typedarray.TypedArrayBuffer.wrap(compressedTypedArray.buffer)
+    val base64EncodedBuffer  = java.util.Base64.getUrlEncoder().encode(compressedBuffer)
+
+    var base64EncodedString = ""
+    while (base64EncodedBuffer.hasRemaining()) {
+      base64EncodedString += base64EncodedBuffer.get().toChar
     }
-    Encoder(compressedSource).toBase64
+    base64EncodedString
   }
 
   def readCompilationResponse(jsonStr: String): CompilationResponse = {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -25,7 +25,7 @@ object Settings {
     val akkaHttp      = "10.1.1"
     val upickle       = "0.4.4"
     val ace           = "1.2.2"
-    val dom           = "0.9.5"
+    val dom           = "0.9.8"
     val scalatags     = "0.6.7"
     val async         = "0.9.7"
     val coursier      = "1.0.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "typesafe" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-RC2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")


### PR DESCRIPTION
This does not change the fact that fiddles themselves are still compiled and linked with Scala.js 0.6.31. However, it shows that we can decouple the version used by fiddles (currently 0.6.31) from the version used by the infrastructure (now 1.0.0-RC2). This is a major step towards adding support for several Scala.js versions in fiddles.