### PR TITLE
Update README.md

### DIFF
--- a/integrations/jekyll/README.md
+++ b/integrations/jekyll/README.md
@@ -21,12 +21,12 @@ plugins:
 
 [sbt-microsites](https://47deg.github.io/sbt-microsites/) is a plugin for sbt that helps Scala developers build and publish 
 documentation for their project. It's based on Jekyll, so you can use this same plugin. Unlike regular Jekyll, you cannot use 
-`gem` to install the plugin, but you must manually copy the `jekyll-scalafiddle.rb` file under a `plugins` directory in your 
-microsite project.
+`gem` to install the plugin, but you must manually copy the `jekyll-scalafiddle.rb` file under a `_plugins` directory in your 
+microsite project (eg in `docs/` by default for an mdoc project).
 
 ```bash
-$ mkdir plugins
-$ cd plugins
+$ mkdir _plugins
+$ cd _plugins
 $ curl -o jekyll-scalafiddle.rb https://raw.githubusercontent.com/scalafiddle/scalafiddle-core/master/integrations/jekyll/lib/jekyll-scalafiddle.rb
 ```
 


### PR DESCRIPTION
`plugins` doesnt work for me in jekyll 4.x, but `_plugins` does, which also aligns with Jekyll plugin docs. 

Also, wasn't 100% clear to me what was meant by "in your microsite project " so I gave an example pathc that works by default with newer mdoc-based sbt-microsites